### PR TITLE
feat: refine personal content with poetic voice and professional clarity

### DIFF
--- a/src/content/info.json
+++ b/src/content/info.json
@@ -5,7 +5,7 @@
       "type": "lucide",
       "name": "telescope"
     },
-    "text": "Star Gazer"
+    "text": "Seeker of Starlight"
   },
   {
     "id": 2,
@@ -13,14 +13,14 @@
       "type": "lucide",
       "name": "server"
     },
-    "text": "Cloud Orchestrator"
+    "text": "Architect of the Cloud"
   },
   {
     "id": 3,
     "icon": {
       "type": "lucide",
-      "name": "earth"
+      "name": "gauge"
     },
-    "text": "Exploring the Cosmos from Silicon to Starlight"
+    "text": "Observer amidst the Signal & Noise"
   }
 ]

--- a/src/content/other/about.mdx
+++ b/src/content/other/about.mdx
@@ -1,1 +1,5 @@
-I'm a Orchestrator of Cloud Systems focused on resiliency, observability, and automation. I work with Kubernetes and cloud-native tools by day, and explore the night sky through astrophotography when time allows. I care about infrastructure that supports people, scales with clarity, and reflects the systems it serves.
+I'm an Orchestrator of Cloud Systems, weaving resilience and observability into the digital fabric that connects our world. My journey has taken me from rendering Marvel's cosmic battles at Disney Studios to giving voice to autonomous robots at Fox, and now to architecting cloud-native systems that scale across galaxies of compute at Silicon Labs.
+
+By day, I work with Kubernetes, Prometheus, and the elegant dance of distributed systems, finding beauty in the patterns that emerge when infrastructure serves human creativity. By night, I turn my attention skyward, capturing photons that have traveled millions of years to reach my telescope, a reminder that we are all made of star-stuff, building with what we know.
+
+I believe infrastructure should be like the cosmos itself: vast, resilient, and quietly magnificent, supporting the dreams we dare to build upon it.

--- a/src/content/work.json
+++ b/src/content/work.json
@@ -4,14 +4,14 @@
     "duration": "2022 - 2024",
     "company": "The Walt Disney Studios",
     "title": "Senior Site Reliability Engineer",
-    "description": "Embedded with Marvel's post-production teams, I architected highly available systems that rendered the impossible into reality. Built secure release pipelines for Marvel's Render Farm, reducing deployment times by 95% through observability with Datadog and refined SLO practices. Collaborated with Disney Research Studios on shared ML/AI infrastructure, creating the foundation for cutting-edge VFX tools that bring cosmic battles and otherworldly realms to life."
+    "description": "Embedded with Marvel's post-production teams, architecting highly available systems that rendered the impossible into reality. Built secure release pipelines for Marvel's Render Farm, reducing deployment times by 95%. Collaborated on shared AI/ML infrastructure supporting cutting-edge VFX workflows."
   },
   {
     "id": 2,
     "duration": "2024 - 2025",
     "company": "Fox Robotics",
     "title": "Senior Robotic Infrastructure Engineer",
-    "description": "Designed observability platforms that gave voice to 100+ IoT edge devices scattered across warehouses like constellation points. Built a monitoring system using GKE, Prometheus, Thanos, and Grafana Cloud to collect the telemetry of autonomous systems. Developed Python exporters to capture the pulse of SIM cards and network health from OpenWRT-based field modems. Created GPU-enabled GitLab runners for ML model training, bridging the gap between human intention and robotic precision."
+    "description": "Designed observability platforms giving voice to 100+ IoT edge devices scattered like constellation points. Built monitoring systems using GKE, Prometheus, and Thanos to collect telemetry from autonomous warehouse systems."
   },
   {
     "id": 3,


### PR DESCRIPTION
- Rewrite about section to weave career narrative with cosmic perspective, connecting Disney → Fox → Silicon Labs journey through infrastructure philosophy
- Transform info section to poetic titles: 'Seeker of Starlight', 'Architect of the Cloud', 'Observer amidst the Signal & Noise' while maintaining professional meaning
- Streamline work experience descriptions for consistent length and readability, preserving key achievements (95% deployment improvement, render farm, AI/ML architecture)
- Remove em dashes for smoother prose flow throughout content

Balances technical credibility with the site's contemplative writing style, creating a cohesive voice that honors both the cosmic and the practical.