### PR TITLE
refactor: streamline socials to focus on GitHub

### DIFF
--- a/src/content/socials.json
+++ b/src/content/socials.json
@@ -7,14 +7,5 @@
     },
     "text": "GitHub",
     "link": "https://github.com/taco-ops"
-  },
-  {
-    "id": 2,
-    "icon": {
-      "type": "lucide",
-      "name": "globe"
-    },
-    "text": "Website",
-    "link": "https://tacoops.io"
   }
 ]


### PR DESCRIPTION
Remove website link from socials section to avoid redundancy since visitors are already on the main site. Keeps the social links focused on external platforms for connecting with the portfolio owner.